### PR TITLE
Error when running BuildAndPack.ps1 - nuget not found

### DIFF
--- a/BuildAndPack.ps1
+++ b/BuildAndPack.ps1
@@ -10,5 +10,5 @@ $version = "$semver-alpha$epoch"
 new-item .\packages\obj -type directory -force | out-null
 get-childitem *.nuspec -Recurse | 
     where { $_.FullName -notmatch '\\packages\\' } | 
-    foreach { nuget pack $_.FullName -version $version -o packages\obj } | 
+    foreach { .nuget\nuget pack $_.FullName -version $version -o packages\obj } | 
     out-null


### PR DESCRIPTION
I opened a powershell in the root of the repository and executed ``.\BuildAndPack.ps1``
It failed with these errors:

![image](https://cloud.githubusercontent.com/assets/4236651/15187295/dd0e8800-17a0-11e6-85fb-0f5582a30f08.png)

> The Name "nuget" was not detected as name of a cmdlet, a function, a scriptfile or an executable program. check the spelling of the name, or if the path is correct.

Do you maybe have a different nuget.exe on the path somewhere else?
With the proposed change, it executes successfully on my machine.