### PR TITLE
Fix issue #2

### DIFF
--- a/StackExchange.Precompilation.Build/PrecompilationCommandLineParser.cs
+++ b/StackExchange.Precompilation.Build/PrecompilationCommandLineParser.cs
@@ -88,9 +88,7 @@ namespace StackExchange.Precompilation
                 }
                 else if(arg.StartsWith("/r:") || arg.StartsWith("/reference:"))
                 {
-                    // don't care about extern stuff for now..
-                    // https://msdn.microsoft.com/en-us/library/ms173212.aspx
-                    references.Add(ParseFileFromArg(arg));
+                    references.Add(ParseFileFromReference(arg));
                 }
                 else if(arg.StartsWith("/appconfig:"))
                 {
@@ -104,6 +102,16 @@ namespace StackExchange.Precompilation
         private static string ParseFileFromArg(string arg, char delimiter = ':')
         {
             return Path.GetFullPath(arg.Substring(arg.IndexOf(delimiter) + 1));
+        }
+
+        private static string ParseFileFromReference(string arg)
+        {
+            var rxReference = new Regex("/(r|(reference)):([a-zA-Z0-9]*=)?(?<ref>.*)");
+            var match = rxReference.Match(arg);
+            if (!match.Success)
+                throw new Exception($"Could not find a reference in {arg}");
+            var reference = match.Groups["ref"].Value;
+            return Path.GetFullPath(reference);
         }
     }
 }

--- a/StackExchange.Precompilation.Tests/CommandLineTests.cs
+++ b/StackExchange.Precompilation.Tests/CommandLineTests.cs
@@ -38,8 +38,11 @@ namespace StackExchange.Precompilation.Tests
         [Test]
         [TestCase("a b c", new string[0], (string)null)]
         [TestCase("a b /r:c.dll", new[] { "c.dll" }, (string)null)]
+        [TestCase("a b /r:a=c.dll", new[] { "c.dll" }, (string)null)]
+        [TestCase("a b /reference:a=c.dll", new[] { "c.dll" }, (string)null)]
         [TestCase("a b /r:c.dll /r:d.dll", new[] { "c.dll", "d.dll" }, (string)null)]
         [TestCase("a b /r:c.dll /appconfig:moar.config /r:d.dll", new[] { "c.dll", "d.dll" }, "moar.config")]
+        [TestCase("a b /r:alias=c.dll /appconfig:moar.config /reference:d.dll", new[] { "c.dll", "d.dll" }, "moar.config")]
         public void ParseArgumentCases(string cmdline, string[] references, string appconfig)
         {
             var dir = Guid.NewGuid().ToString();

--- a/StackExchange.Precompilation.Tests/StackExchange.Precompilation.Tests.csproj
+++ b/StackExchange.Precompilation.Tests/StackExchange.Precompilation.Tests.csproj
@@ -32,9 +32,25 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -56,6 +72,9 @@
       <Project>{31DFCCCC-2F44-405E-A2D7-BB1AC718E7B9}</Project>
       <Name>StackExchange.Precompilation.Build</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/StackExchange.Precompilation.Tests/packages.config
+++ b/StackExchange.Precompilation.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The second commit allows to run the Tests in the VS TestExplorer without any Extensions installed.

I don't think adding the nuget has any downsides, but if you mind I can re-send the PR with only the first commit.
